### PR TITLE
fix logo not apearing on the video list

### DIFF
--- a/pages/html/list.html
+++ b/pages/html/list.html
@@ -24,7 +24,7 @@
 <header>
 	<div class="header_content">
 		<div id="logo_container">
-			<img id="logo" src="../pages/img/logo.png" alt="Wrapper: Online"/>
+			<img id="logo" src="../img/logo.png" alt="Wrapper: Online"/>
 			
 		</div>
 		<nav id="headbuttons">


### PR DESCRIPTION
i was doing some testing on your new wrapper offline 2.0.0, but when i went into the new video list, the logo was white the way it was not supposed to be. removing the ../pages/img/logo.png and putting in the ../img/logo.png should fix the problem. i will be thankful if you merge this pull request.